### PR TITLE
Move TableViewCell dividers to the contentView

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -950,8 +950,8 @@ open class TableViewCell: UITableViewCell {
         contentView.addSubview(subtitleLabel)
         contentView.addSubview(footerLabel)
         contentView.addSubview(selectionImageView)
-        addSubview(topSeparator.view)
-        addSubview(bottomSeparator.view)
+        contentView.addSubview(topSeparator.view)
+        contentView.addSubview(bottomSeparator.view)
 
         setupBackgroundColors()
 
@@ -1066,9 +1066,6 @@ open class TableViewCell: UITableViewCell {
 
         layoutContentSubviews()
         contentView.flipSubviewsForRTL()
-
-        layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
-        layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.state.thickness)
     }
 
     open func layoutContentSubviews() {
@@ -1117,6 +1114,9 @@ open class TableViewCell: UITableViewCell {
             let yOffset = UIScreen.main.roundToDevicePixels((contentView.frame.height - _accessoryType.size.height) / 2)
             accessoryTypeView.frame = CGRect(origin: CGPoint(x: xOffset, y: yOffset), size: _accessoryType.size)
         }
+
+        layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
+        layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.state.thickness)
     }
 
     private func layoutLabelViews(label: UILabel, numberOfLines: Int, topOffset: CGFloat, leadingAccessoryView: UIView?, leadingAccessoryViewSize: CGSize, trailingAccessoryView: UIView?, trailingAccessoryViewSize: CGSize) {
@@ -1170,7 +1170,6 @@ open class TableViewCell: UITableViewCell {
             width: frame.width - separatorLeadingInset(for: type),
             height: separator.state.thickness
         )
-        separator.view.flipForRTL()
     }
 
     func separatorLeadingInset(for type: SeparatorType) -> CGFloat {


### PR DESCRIPTION
Move the dividers to the TableViewCell's content view rather than adding them as direct subviews. Also move the layout calls to layoutContentSubviews.

### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Subview_LTR](https://user-images.githubusercontent.com/67026548/148312474-dc10e775-1bd8-4a72-980c-c717d2825377.png) | ![Contentview_LTR](https://user-images.githubusercontent.com/67026548/148312491-c4c74830-d25c-40e8-b132-0c3a1103c3c0.png) |
| ![Subview_RTL](https://user-images.githubusercontent.com/67026548/148312484-7195e9ef-5234-4ce1-9140-a9b818cd8454.png) | ![Contentview_RTL](https://user-images.githubusercontent.com/67026548/148312504-db44c692-392a-4962-82c2-21ed26841b4c.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
