### PR TITLE
Improve SwiftUI Theme support

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		EC24DBC628B97EB70026EF92 /* PopupMenuObjCDemoController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */; };
 		EC98E2B62992FE5000B9DF91 /* TextFieldObjCDemoController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC98E2B52992FE5000B9DF91 /* TextFieldObjCDemoController.m */; };
 		ECA9D48A2979F5370048ADEC /* TextFieldDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9D4892979F5370048ADEC /* TextFieldDemoController.swift */; };
+		ECD95F5E2A0B19FF00152742 /* BrandedSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD95F5D2A0B19FF00152742 /* BrandedSwitch.swift */; };
 		FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC414E3625888BC300069E73 /* CommandBarDemoController.swift */; };
 		FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */; };
 /* End PBXBuildFile section */
@@ -265,6 +266,7 @@
 		EC98E2B52992FE5000B9DF91 /* TextFieldObjCDemoController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TextFieldObjCDemoController.m; sourceTree = "<group>"; };
 		EC98E2B72992FE6900B9DF91 /* TextFieldObjCDemoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextFieldObjCDemoController.h; sourceTree = "<group>"; };
 		ECA9D4892979F5370048ADEC /* TextFieldDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldDemoController.swift; sourceTree = "<group>"; };
+		ECD95F5D2A0B19FF00152742 /* BrandedSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandedSwitch.swift; sourceTree = "<group>"; };
 		FC414E3625888BC300069E73 /* CommandBarDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarDemoController.swift; sourceTree = "<group>"; };
 		FD41C8F322E28EEB0086F899 /* NavigationControllerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationControllerDemoController.swift; sourceTree = "<group>"; };
 		FD6AE76C225679A4002CFDFE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -557,6 +559,7 @@
 			isa = PBXGroup;
 			children = (
 				92E977B626C713F3008E10A8 /* ScrollView */,
+				ECD95F5D2A0B19FF00152742 /* BrandedSwitch.swift */,
 				B4414791228F6F740040E88E /* TableViewCellSampleData.swift */,
 				B4414793228F6FDF0040E88E /* OtherCellsSampleData.swift */,
 				B4EF66552295F729007FEAB0 /* TableViewHeaderFooterSampleData.swift */,
@@ -787,6 +790,7 @@
 				5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */,
 				7D0931C124AAA3D30072458A /* SideTabBarDemoController.swift in Sources */,
 				80B1F7012628D8BB004DFEE5 /* BottomSheetDemoController.swift in Sources */,
+				ECD95F5E2A0B19FF00152742 /* BrandedSwitch.swift in Sources */,
 				FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */,
 				B45EB79221A4D047008646A2 /* BadgeFieldDemoController.swift in Sources */,
 				B4EF66562295F729007FEAB0 /* TableViewHeaderFooterSampleData.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/BrandedSwitch.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/BrandedSwitch.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+class BrandedSwitch: UISwitch {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        NotificationCenter.default.addObserver(forName: .didChangeTheme,
+                                               object: nil,
+                                               queue: nil) { [weak self] notification in
+            guard let strongSelf = self,
+                  let themeView = notification.object as? UIView,
+                  strongSelf.isDescendant(of: themeView)
+            else {
+                return
+            }
+            strongSelf.onTintColor = themeView.fluentTheme.color(.brandForeground1)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        onTintColor = newWindow.fluentTheme.color(.brandForeground1)
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -95,6 +95,7 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
 
         // Different themes can have different overrides, so update as needed.
         updateToggleConfiguration()
+        rootView.fluentTheme = window.fluentTheme
     }
 
     /// Callback for handling color scheme changes.

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
@@ -13,6 +13,7 @@ struct DemoAppearanceView: View {
     @Environment(\.colorScheme) var systemColorScheme: ColorScheme
     @ObservedObject var configuration: Configuration
     @State var showingThemeWideAlert: Bool = false
+    @ObservedObject var fluentTheme: FluentTheme = .shared
 
     /// Picker for setting the app's color scheme.
     @ViewBuilder
@@ -68,6 +69,7 @@ struct DemoAppearanceView: View {
 
             Spacer()
         }
+        .fluentTheme(fluentTheme)
     }
 
     var body: some View {

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -110,14 +110,6 @@ class DemoController: UIViewController {
 
     }
 
-    func createLabelAndSwitchRow(labelText: String, switchAction: Selector, isOn: Bool = false) -> UIView {
-        let switchView = UISwitch()
-        switchView.isOn = isOn
-        switchView.addTarget(self, action: switchAction, for: .valueChanged)
-
-        return createLabelAndViewsRow(labelText: labelText, views: [switchView])
-    }
-
     func createLabelAndViewsRow(labelText: String, views: [UIView]) -> UIView {
         let stackView = UIStackView(frame: .zero)
         stackView.axis = .horizontal

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController_SwiftUI.swift
@@ -86,5 +86,6 @@ struct ActivityIndicatorDemoView: View {
             }
         }
         .fluentTheme(fluentTheme)
+        .tint(Color(fluentTheme.color(.brandForeground1)))
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController_SwiftUI.swift
@@ -20,6 +20,15 @@ class ActivityIndicatorDemoControllerSwiftUI: UIHostingController<ActivityIndica
         super.init(rootView: ActivityIndicatorDemoView())
         self.title = "ActivityIndicator Fluent 2 (SwiftUI)"
     }
+
+    override func willMove(toParent parent: UIViewController?) {
+        guard let parent,
+              let window = parent.view.window else {
+            return
+        }
+
+        rootView.fluentTheme = window.fluentTheme
+    }
 }
 
 struct ActivityIndicatorDemoView: View {
@@ -27,6 +36,7 @@ struct ActivityIndicatorDemoView: View {
     @State var hidesWhenStopsAnimating: Bool = true
     @State var usesCustomColor: Bool = false
     @State var size: MSFActivityIndicatorSize = .xLarge
+    @ObservedObject var fluentTheme: FluentTheme = .shared
 
     public var body: some View {
         VStack {
@@ -75,5 +85,6 @@ struct ActivityIndicatorDemoView: View {
                 .padding()
             }
         }
+        .fluentTheme(fluentTheme)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -196,5 +196,6 @@ struct AvatarDemoView: View {
             }
         }
         .fluentTheme(fluentTheme)
+        .tint(Color(fluentTheme.color(.brandForeground1)))
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -20,6 +20,15 @@ class AvatarDemoControllerSwiftUI: UIHostingController<AvatarDemoView> {
         super.init(rootView: AvatarDemoView())
         self.title = "Avatar Fluent 2 (SwiftUI)"
     }
+
+    override func willMove(toParent parent: UIViewController?) {
+        guard let parent,
+              let window = parent.view.window else {
+            return
+        }
+
+        rootView.fluentTheme = window.fluentTheme
+    }
 }
 
 struct AvatarDemoView: View {
@@ -39,6 +48,7 @@ struct AvatarDemoView: View {
     @State var showImageBasedRingColor: Bool = false
     @State var size: MSFAvatarSize = .size72
     @State var style: MSFAvatarStyle = .default
+    @ObservedObject var fluentTheme: FluentTheme = .shared
 
     public var body: some View {
         VStack {
@@ -185,5 +195,6 @@ struct AvatarDemoView: View {
                 .padding()
             }
         }
+        .fluentTheme(fluentTheme)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -359,6 +359,7 @@ class CommandBarDemoController: DemoController {
         let label = Label()
         label.text = text
         label.textAlignment = .center
+        label.numberOfLines = 0
         return label
     }
 
@@ -415,8 +416,9 @@ class CommandBarDemoController: DemoController {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.distribution = .fillProportionally
         stackView.spacing = CommandBarDemoController.horizontalStackViewSpacing
+        stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: CommandBarDemoController.horizontalStackViewSpacing, bottom: 0, trailing: CommandBarDemoController.horizontalStackViewSpacing)
+        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -232,7 +232,7 @@ class CommandBarDemoController: DemoController {
 
         let deleteAccentImageStackView = createHorizontalStackView()
         deleteAccentImageStackView.addArrangedSubview(createLabelWithText("\"Delete\" Accent Image"))
-        let deleteAccentImageSwitch: UISwitch = UISwitch()
+        let deleteAccentImageSwitch: BrandedSwitch = BrandedSwitch()
         deleteAccentImageSwitch.isOn = true
         deleteAccentImageSwitch.addTarget(self, action: #selector(deleteAccentImageValueChange), for: .valueChanged)
         deleteAccentImageStackView.addArrangedSubview(deleteAccentImageSwitch)
@@ -240,7 +240,7 @@ class CommandBarDemoController: DemoController {
 
         let itemEnabledStackView = createHorizontalStackView()
         itemEnabledStackView.addArrangedSubview(createLabelWithText("'+' Enabled"))
-        let itemEnabledSwitch: UISwitch = UISwitch()
+        let itemEnabledSwitch: BrandedSwitch = BrandedSwitch()
         itemEnabledSwitch.isOn = true
         itemEnabledSwitch.addTarget(self, action: #selector(itemEnabledValueChanged), for: .valueChanged)
         itemEnabledStackView.addArrangedSubview(itemEnabledSwitch)
@@ -248,7 +248,7 @@ class CommandBarDemoController: DemoController {
 
         let disableMenuItemsStackView = createHorizontalStackView()
         disableMenuItemsStackView.addArrangedSubview(createLabelWithText("Disable Undo Menu Items"))
-        let disableMenuItemsSwitch: UISwitch = UISwitch()
+        let disableMenuItemsSwitch: BrandedSwitch = BrandedSwitch()
         disableMenuItemsSwitch.isOn = false
         disableMenuItemsSwitch.addTarget(self, action: #selector(disableMenuItemValueChanged), for: .valueChanged)
         disableMenuItemsStackView.addArrangedSubview(disableMenuItemsSwitch)
@@ -256,7 +256,7 @@ class CommandBarDemoController: DemoController {
 
         let itemHiddenStackView = createHorizontalStackView()
         itemHiddenStackView.addArrangedSubview(createLabelWithText("'Delete' Hidden"))
-        let itemHiddenSwitch: UISwitch = UISwitch()
+        let itemHiddenSwitch: BrandedSwitch = BrandedSwitch()
         itemHiddenSwitch.isOn = false
         itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
         itemHiddenStackView.addArrangedSubview(itemHiddenSwitch)
@@ -264,7 +264,7 @@ class CommandBarDemoController: DemoController {
 
         let commandBarDelegateEventAnimationView = createHorizontalStackView()
         commandBarDelegateEventAnimationView.addArrangedSubview(createLabelWithText("Animate CommandBarDelegate Events"))
-        let commandBarDelegateEventAnimationSwitch: UISwitch = UISwitch()
+        let commandBarDelegateEventAnimationSwitch: BrandedSwitch = BrandedSwitch()
         commandBarDelegateEventAnimationSwitch.isOn = animateCommandBarDelegateEvents
         commandBarDelegateEventAnimationSwitch.addTarget(self, action: #selector(animateCommandBarDelegateEventsValueChanged), for: .valueChanged)
         commandBarDelegateEventAnimationView.addArrangedSubview(commandBarDelegateEventAnimationSwitch)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
@@ -23,7 +23,7 @@ class DateTimePickerDemoController: DemoController {
         }
     }
 
-    private let customCalendarConfigurationSwitch = UISwitch()
+    private let customCalendarConfigurationSwitch = BrandedSwitch()
     private var calendarConfiguration: CalendarConfiguration? {
         guard customCalendarConfigurationSwitch.isOn else {
             return nil
@@ -37,7 +37,7 @@ class DateTimePickerDemoController: DemoController {
         return customCalendarConfiguration
     }
 
-    private let validationSwitch = UISwitch()
+    private let validationSwitch = BrandedSwitch()
     private var isValidating: Bool { return validationSwitch.isOn }
 
     private var startDate: Date?

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController_SwiftUI.swift
@@ -20,42 +20,55 @@ class DividerDemoControllerSwiftUI: UIHostingController<DividerDemoView> {
         super.init(rootView: DividerDemoView())
         self.title = "Divider (SwiftUI)"
     }
+
+    override func willMove(toParent parent: UIViewController?) {
+        guard let parent,
+              let window = parent.view.window else {
+            return
+        }
+
+        rootView.fluentTheme = window.fluentTheme
+    }
 }
 
 struct DividerDemoView: View {
     @State var spacing: MSFDividerSpacing = .none
+    @ObservedObject var fluentTheme: FluentTheme = .shared
 
     public var body: some View {
-        VStack (spacing: 0) {
-            FluentDivider(spacing: spacing)
-            HStack (spacing: 0) {
-                FluentDivider(orientation: .vertical, spacing: spacing)
-                Text("Text 1")
-                FluentDivider(orientation: .vertical, spacing: spacing)
-                Text("Text 2")
-                FluentDivider(orientation: .vertical, spacing: spacing)
-            }
-            .frame(maxHeight: 20)
-            FluentDivider(spacing: spacing)
-        }
-
-        ScrollView {
-            Group {
-                VStack(spacing: 0) {
-                    Text("Spacing")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .font(.title)
-                    FluentDivider(orientation: .horizontal)
+        VStack() {
+            VStack (spacing: 0) {
+                FluentDivider(spacing: spacing)
+                HStack (spacing: 0) {
+                    FluentDivider(orientation: .vertical, spacing: spacing)
+                    Text("Text 1")
+                    FluentDivider(orientation: .vertical, spacing: spacing)
+                    Text("Text 2")
+                    FluentDivider(orientation: .vertical, spacing: spacing)
                 }
-
-                Picker(selection: $spacing, label: EmptyView()) {
-                    Text(".none").tag(MSFDividerSpacing.none)
-                    Text(".medium").tag(MSFDividerSpacing.medium)
-                }
-                .labelsHidden()
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxHeight: 20)
+                FluentDivider(spacing: spacing)
             }
+
+            ScrollView {
+                Group {
+                    VStack(spacing: 0) {
+                        Text("Spacing")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .font(.title)
+                        FluentDivider(orientation: .horizontal)
+                    }
+                    
+                    Picker(selection: $spacing, label: EmptyView()) {
+                        Text(".none").tag(MSFDividerSpacing.none)
+                        Text(".medium").tag(MSFDividerSpacing.medium)
+                    }
+                    .labelsHidden()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding()
         }
-        .padding()
+        .fluentTheme(fluentTheme)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController_SwiftUI.swift
@@ -36,7 +36,7 @@ struct DividerDemoView: View {
     @ObservedObject var fluentTheme: FluentTheme = .shared
 
     public var body: some View {
-        VStack() {
+        VStack {
             VStack (spacing: 0) {
                 FluentDivider(spacing: spacing)
                 HStack (spacing: 0) {
@@ -58,7 +58,7 @@ struct DividerDemoView: View {
                             .font(.title)
                         FluentDivider(orientation: .horizontal)
                     }
-                    
+
                     Picker(selection: $spacing, label: EmptyView()) {
                         Text(".none").tag(MSFDividerSpacing.none)
                         Text(".medium").tag(MSFDividerSpacing.medium)
@@ -70,5 +70,6 @@ struct DividerDemoView: View {
             .padding()
         }
         .fluentTheme(fluentTheme)
+        .tint(Color(fluentTheme.color(.brandForeground1)))
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController_SwiftUI.swift
@@ -103,6 +103,7 @@ struct HUDDemoView: View {
                     isPresented: $isPresented,
                     label: label)
         .fluentTheme(fluentTheme)
+        .tint(Color(fluentTheme.color(.brandForeground1)))
     }
 
     @State var isBlocking: Bool = true

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController_SwiftUI.swift
@@ -20,10 +20,18 @@ class HUDDemoControllerSwiftUI: UIHostingController<HUDDemoView> {
         super.init(rootView: HUDDemoView())
         self.title = "HUD (SwiftUI)"
     }
+
+    override func willMove(toParent parent: UIViewController?) {
+        guard let parent,
+              let window = parent.view.window else {
+            return
+        }
+
+        rootView.fluentTheme = window.fluentTheme
+    }
 }
 
 struct HUDDemoView: View {
-
     public var body: some View {
         VStack {
             HeadsUpDisplay(type: type,
@@ -94,10 +102,12 @@ struct HUDDemoView: View {
                     isBlocking: isBlocking,
                     isPresented: $isPresented,
                     label: label)
+        .fluentTheme(fluentTheme)
     }
 
     @State var isBlocking: Bool = true
     @State var isPresented: Bool = false
     @State var label: String = ""
     @State var type: HUDType = .activity
+    @ObservedObject var fluentTheme: FluentTheme = .shared
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController_SwiftUI.swift
@@ -20,11 +20,21 @@ class IndeterminateProgressBarDemoControllerSwiftUI: UIHostingController<Indeter
         super.init(rootView: IndeterminateProgressBarDemoView())
         self.title = "IndeterminateProgressBar Fluent 2 (SwiftUI)"
     }
+
+    override func willMove(toParent parent: UIViewController?) {
+        guard let parent,
+              let window = parent.view.window else {
+            return
+        }
+
+        rootView.fluentTheme = window.fluentTheme
+    }
 }
 
 struct IndeterminateProgressBarDemoView: View {
     @State var isAnimating: Bool = true
     @State var hidesWhenStopsAnimating: Bool = true
+    @ObservedObject var fluentTheme: FluentTheme = .shared
 
     public var body: some View {
         VStack {
@@ -52,5 +62,6 @@ struct IndeterminateProgressBarDemoView: View {
                 .padding()
             }
         }
+        .fluentTheme(fluentTheme)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -51,11 +51,13 @@ struct NotificationDemoView: View {
     @State var useCustomTheme: Bool = false
     @ObservedObject var fluentTheme: FluentTheme = .shared
     let customTheme: FluentTheme = {
+        let foregroundColor = UIColor(light: GlobalTokens.sharedColor(.lavender, .shade30),
+                                      dark: GlobalTokens.sharedColor(.lavender, .tint40))
         let colorOverrides = [
             FluentTheme.ColorToken.brandBackgroundTint: UIColor(light: GlobalTokens.sharedColor(.lavender, .tint40),
                                                                 dark: GlobalTokens.sharedColor(.lavender, .shade30)),
-            FluentTheme.ColorToken.brandForegroundTint: UIColor(light: GlobalTokens.sharedColor(.lavender, .shade30),
-                                                                dark: GlobalTokens.sharedColor(.lavender, .tint40))
+            FluentTheme.ColorToken.brandForeground1: foregroundColor,
+            FluentTheme.ColorToken.brandForegroundTint: foregroundColor
         ]
         return FluentTheme(colorOverrides: colorOverrides)
     }()
@@ -278,6 +280,7 @@ struct NotificationDemoView: View {
             .overrideTokens($overrideTokens.wrappedValue ? notificationOverrideTokens : nil)
         }
         .fluentTheme(theme)
+        .tint(Color(theme.color(.brandForeground1)))
     }
 
     private var backgroundGradient: LinearGradientInfo {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -162,8 +162,6 @@ struct NotificationDemoView: View {
                     Alert(title: Text("Button tapped"))
                 })
 
-            Text("Test").foregroundColor(Color(fluentTheme.color(.brandForeground1)))
-
             Button("Show") {
                 if isPresented == false {
                     isPresented = true

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -19,6 +19,15 @@ class NotificationViewDemoControllerSwiftUI: UIHostingController<NotificationDem
         super.init(rootView: NotificationDemoView())
         self.title = "Notification View Vnext (SwiftUI)"
     }
+
+    override func willMove(toParent parent: UIViewController?) {
+        guard let parent,
+              let window = parent.view.window else {
+            return
+        }
+
+        rootView.fluentTheme = window.fluentTheme
+    }
 }
 
 struct NotificationDemoView: View {
@@ -39,6 +48,7 @@ struct NotificationDemoView: View {
     @State var showDefaultDismissActionButton: Bool = true
     @State var showFromBottom: Bool = true
     @State var showBackgroundGradient: Bool = false
+    @ObservedObject var fluentTheme: FluentTheme = .shared
 
     public var body: some View {
         let font = UIFont(descriptor: .init(name: "Papyrus", size: 30.0), size: 30.0)
@@ -152,6 +162,8 @@ struct NotificationDemoView: View {
                     Alert(title: Text("Button tapped"))
                 })
 
+            Text("Test").foregroundColor(Color(fluentTheme.color(.brandForeground1)))
+
             Button("Show") {
                 if isPresented == false {
                     isPresented = true
@@ -255,6 +267,7 @@ struct NotificationDemoView: View {
             .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)
             .overrideTokens($overrideTokens.wrappedValue ? notificationOverrideTokens : nil)
         }
+        .fluentTheme(fluentTheme)
     }
 
     private var backgroundGradient: LinearGradientInfo {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -48,7 +48,17 @@ struct NotificationDemoView: View {
     @State var showDefaultDismissActionButton: Bool = true
     @State var showFromBottom: Bool = true
     @State var showBackgroundGradient: Bool = false
+    @State var useCustomTheme: Bool = false
     @ObservedObject var fluentTheme: FluentTheme = .shared
+    let customTheme: FluentTheme = {
+        let colorOverrides = [
+            FluentTheme.ColorToken.brandBackgroundTint: UIColor(light: GlobalTokens.sharedColor(.lavender, .tint40),
+                                                                dark: GlobalTokens.sharedColor(.lavender, .shade30)),
+            FluentTheme.ColorToken.brandForegroundTint: UIColor(light: GlobalTokens.sharedColor(.lavender, .shade30),
+                                                                dark: GlobalTokens.sharedColor(.lavender, .tint40))
+        ]
+        return FluentTheme(colorOverrides: colorOverrides)
+    }()
 
     public var body: some View {
         let font = UIFont(descriptor: .init(name: "Papyrus", size: 30.0), size: 30.0)
@@ -80,6 +90,7 @@ struct NotificationDemoView: View {
         let messageButtonAction = hasMessageAction ? { showAlert = true } : nil
         let hasMessage = !message.isEmpty
         let hasTitle = !title.isEmpty
+        let theme = useCustomTheme ? customTheme : fluentTheme
 
 #if DEBUG
         let accessibilityIdentifier: String = {
@@ -240,6 +251,7 @@ struct NotificationDemoView: View {
                         FluentUIDemoToggle(titleKey: "Flexible Width Toast", isOn: $isFlexibleWidthToast)
                         FluentUIDemoToggle(titleKey: "Present From Bottom", isOn: $showFromBottom)
                         FluentUIDemoToggle(titleKey: "Background Gradient", isOn: $showBackgroundGradient)
+                        FluentUIDemoToggle(titleKey: "Custom theme", isOn: $useCustomTheme)
                     }
                 }
                 .padding()
@@ -265,7 +277,7 @@ struct NotificationDemoView: View {
             .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)
             .overrideTokens($overrideTokens.wrappedValue ? notificationOverrideTokens : nil)
         }
-        .fluentTheme(fluentTheme)
+        .fluentTheme(theme)
     }
 
     private var backgroundGradient: LinearGradientInfo {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -60,7 +60,7 @@ final class AsyncImageDemoPersona: PersonaData {
 class PeoplePickerDemoController: DemoController {
     var peoplePickers: [PeoplePicker] = []
 
-    private let asyncImageSwitch = UISwitch()
+    private let asyncImageSwitch = BrandedSwitch()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -22,7 +22,7 @@ class PillButtonBarDemoController: DemoController {
                                           PillButtonBarItem(title: "Actions"),
                                           PillButtonBarItem(title: "More")]
 
-        let disableOnBrandSwitchView = UISwitch()
+        let disableOnBrandSwitchView = BrandedSwitch()
         disableOnBrandSwitchView.isOn = true
         disableOnBrandSwitchView.addTarget(self, action: #selector(toggleOnBrandPills(switchView:)), for: .valueChanged)
 
@@ -33,7 +33,7 @@ class PillButtonBarDemoController: DemoController {
         self.onBrandBar = onBrandBar
         container.addArrangedSubview(UIView())
 
-        let disableCustomOnBrandSwitchView = UISwitch()
+        let disableCustomOnBrandSwitchView = BrandedSwitch()
         disableCustomOnBrandSwitchView.isOn = true
         disableCustomOnBrandSwitchView.addTarget(self, action: #selector(toggleCustomOnBrandPills(switchView:)), for: .valueChanged)
 
@@ -44,7 +44,7 @@ class PillButtonBarDemoController: DemoController {
         self.customBar = customBar
         container.addArrangedSubview(UIView())
 
-        let disablePrimarySwitchView = UISwitch()
+        let disablePrimarySwitchView = BrandedSwitch()
         disablePrimarySwitchView.isOn = true
         disablePrimarySwitchView.addTarget(self, action: #selector(togglePrimaryPills(switchView:)), for: .valueChanged)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -20,9 +20,9 @@ class TabBarViewDemoController: DemoController {
     private var showBadgeNumbers: Bool { return showBadgeNumbersSwitch.isOn }
     private var useHigherBadgeNumbers: Bool { return useHigherBadgeNumbersSwitch.isOn }
 
-    private let itemTitleVisibilitySwitch = UISwitch()
-    private let showBadgeNumbersSwitch = UISwitch()
-    private let useHigherBadgeNumbersSwitch = UISwitch()
+    private let itemTitleVisibilitySwitch = BrandedSwitch()
+    private let showBadgeNumbersSwitch = BrandedSwitch()
+    private let useHigherBadgeNumbersSwitch = BrandedSwitch()
 
     private lazy var incrementBadgeButton: Button = {
         return createButton(title: "+", action: #selector(incrementBadgeNumbers))

--- a/ios/FluentUI.Demo/FluentUI.Demo/SwiftUI/FluentUIDemoToggle.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/SwiftUI/FluentUIDemoToggle.swift
@@ -9,13 +9,10 @@ import SwiftUI
 struct FluentUIDemoToggle: View {
     var titleKey: LocalizedStringKey
     var isOn: Binding<Bool>
-
-    let switchToggleStyle: SwitchToggleStyle = {
-        return SwitchToggleStyle(tint: Color(UIColor(colorValue: GlobalTokens.brandColors(.comm80))))
-    }()
+    @Environment(\.fluentTheme) var fluentTheme: FluentTheme
 
     var body: some View {
         Toggle(titleKey, isOn: isOn)
-            .toggleStyle(switchToggleStyle)
+            .tint(Color(fluentTheme.color(.brandForeground1)))
     }
 }

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
@@ -40,6 +40,7 @@ public struct ActivityIndicator: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         let side = ActivityIndicatorTokenSet.sideLength(size: state.size)
         let color: Color = {
             guard let stateUIColor = state.color else {
@@ -75,7 +76,7 @@ public struct ActivityIndicator: View, TokenizedControlView {
                                 accessibilityLabel: accessibilityLabel)
 #endif
 
-        semiRing
+        return semiRing
             .modifyIf(state.isAnimating, { animatedView in
                 animatedView
                     .rotationEffect(.degrees(rotationAngle), anchor: .center)
@@ -86,7 +87,7 @@ public struct ActivityIndicator: View, TokenizedControlView {
             .modifyIf(!state.isAnimating) { staticView in
                 staticView
                     .onAppear {
-                       stopAnimation()
+                        stopAnimation()
                     }
             }
             .modifyIf(!state.isAnimating && state.hidesWhenStopped, { view in
@@ -95,7 +96,6 @@ public struct ActivityIndicator: View, TokenizedControlView {
             .frame(width: side,
                    height: side,
                    alignment: .center)
-            .fluentTokens(tokenSet, fluentTheme)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -108,6 +108,7 @@ public struct Avatar: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         let style = state.style
         let size = state.size
 
@@ -390,7 +391,6 @@ public struct Avatar: View, TokenizedControlView {
 #if DEBUG
             .accessibilityIdentifier(accessibilityIdentifier)
 #endif
-            .fluentTokens(tokenSet, fluentTheme)
     }
 
     /// Internal initializer. Used by our public init, and also by internal container views. These containers should first initialize

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -106,6 +106,7 @@ public struct AvatarGroup: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         let avatars: [MSFAvatarStateImpl] = state.avatars
         let avatarViews: [Avatar] = avatars.map { Avatar($0) }
         let enumeratedAvatars = Array(avatars.enumerated())
@@ -220,7 +221,6 @@ public struct AvatarGroup: View, TokenizedControlView {
         }
 
         return avatarGroupContent
-            .fluentTokens(tokenSet, fluentTheme)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -56,7 +56,7 @@ public protocol BadgeViewDelegate {
  `BadgeView` can be selected with a tap gesture and tapped again after entering a selected state for the purpose of displaying more details about the entity represented by the selected badge.
  */
 @objc(MSFBadgeView)
-open class BadgeView: UIView, TokenizedControlInternal {
+open class BadgeView: UIView, TokenizedThemeObserver {
     @objc open var dataSource: BadgeViewDataSource? {
         didSet {
             reload()
@@ -208,6 +208,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
             self?.updateColors()
             self?.updateFonts()
         }
+        addThemeObserver(for: self)
 
         defer {
             self.dataSource = dataSource

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -40,7 +40,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 }
 
 @objc(MSFBottomSheetController)
-public class BottomSheetController: UIViewController, Shadowable, TokenizedControlInternal {
+public class BottomSheetController: UIViewController, Shadowable, TokenizedThemeObserver {
 
     /// Initializes the bottom sheet controller
     /// - Parameters:
@@ -398,6 +398,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         tokenSet.registerOnUpdate(for: view) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: view)
     }
 
     // MARK: - Shadow Layers

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -10,7 +10,7 @@ import UIKit
 /// By default, `titleLabel`'s `adjustsFontForContentSizeCategory` is set to true for non-floating buttons to automatically update its font when device's content size category changes
 @IBDesignable
 @objc(MSFButton)
-open class Button: UIButton, Shadowable, TokenizedControlInternal {
+open class Button: UIButton, Shadowable, TokenizedThemeObserver {
     @objc open var style: ButtonStyle = .outline {
         didSet {
             if style != oldValue {
@@ -130,11 +130,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.update()
         }
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
+        addThemeObserver(for: self)
     }
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
@@ -214,13 +210,6 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
                                                      size: { [weak self] in
         return self?.sizeCategory ?? .medium
     })
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
-    }
 
     private func updateTitle() {
         let foregroundColor = tokenSet[.foregroundColor].uiColor

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -130,6 +130,11 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.update()
         }
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
@@ -209,6 +214,13 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
                                                      size: { [weak self] in
         return self?.sizeCategory ?? .medium
     })
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
+        tokenSet.update(themeView.fluentTheme)
+    }
 
     private func updateTitle() {
         let foregroundColor = tokenSet[.foregroundColor].uiColor

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -50,7 +50,7 @@ let calendarViewDayCellVisualStateTransitionDuration: TimeInterval = 0.3
 
 // MARK: - CalendarViewDayCell
 
-class CalendarViewDayCell: UICollectionViewCell, TokenizedControlInternal {
+class CalendarViewDayCell: UICollectionViewCell, TokenizedThemeObserver {
     struct Constants {
         static let borderWidth: CGFloat = 0.5
         static let dotDiameter: CGFloat = 6.0
@@ -116,6 +116,7 @@ class CalendarViewDayCell: UICollectionViewCell, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     func updateAppearance() {

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -162,6 +162,7 @@ public struct CardNudge: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
 #if DEBUG
         let accessibilityIdentifier: String = {
             var identifier: String = "Card Nudge with title \"\(state.title)\""
@@ -200,7 +201,7 @@ public struct CardNudge: View, TokenizedControlView {
             return identifier
         }()
 #endif
-        innerContents
+        return innerContents
             .background(
                 RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
                     .strokeBorder(lineWidth: tokenSet[.outlineWidth].float)
@@ -215,7 +216,6 @@ public struct CardNudge: View, TokenizedControlView {
             )
             .padding(.vertical, CardNudgeTokenSet.verticalPadding)
             .padding(.horizontal, CardNudgeTokenSet.horizontalPadding)
-            .fluentTokens(tokenSet, fluentTheme)
     }
 
     public init(style: MSFCardNudgeStyle, title: String) {

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -151,7 +151,7 @@ public enum CardSize: Int, CaseIterable {
  Conform to the `CardDelegate` in order to provide a handler for the card tap event
  */
 @objc(MSFCardView)
-open class CardView: UIView, Shadowable, TokenizedControlInternal {
+open class CardView: UIView, Shadowable, TokenizedThemeObserver {
 
     /// Delegate to handle user interaction with the CardView
     @objc public weak var delegate: CardDelegate?
@@ -320,6 +320,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.setupColors()
         }
+        addThemeObserver(for: self)
 
         translatesAutoresizingMaskIntoConstraints = false
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -18,7 +18,7 @@ public protocol CommandBarDelegate: AnyObject {
  Provide `itemGroups` in `init` to set the buttons in the CommandBar. Optional `leadingItemGroups` and `trailingItemGroups` add buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  */
 @objc(MSFCommandBar)
-public class CommandBar: UIView, TokenizedControlInternal {
+public class CommandBar: UIView, TokenizedThemeObserver {
     // Hierarchy:
     //
     // isScrollable = true
@@ -103,6 +103,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateButtonTokens()
         }
+        addThemeObserver(for: self)
     }
 
     public override func willMove(toWindow newWindow: UIWindow?) {

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -149,7 +149,7 @@ public extension View {
     }
 }
 
-extension EnvironmentValues {
+public extension EnvironmentValues {
     var fluentTheme: FluentTheme {
         get {
             self[FluentThemeKey.self]

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -157,7 +157,7 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
     }
 
     /// The current `FluentTheme` associated with this `ControlTokenSet`.
-    @Published var fluentTheme: FluentTheme = FluentTheme.shared
+    var fluentTheme: FluentTheme = FluentTheme.shared
 
     /// Access to raw overrides for the `ControlTokenSet`.
     @Published private var valueOverrides: [T: ControlTokenValue]?

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -65,13 +65,7 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
     /// Removes all `onUpdate`-based observing. Useful if you are re-registering the same tokenSet
     /// for a new instance of a control (see `Tooltip` for an example).
     func deregisterOnUpdate() {
-        if let notificationObserver {
-            NotificationCenter.default.removeObserver(notificationObserver,
-                                                      name: .didChangeTheme,
-                                                      object: nil)
-        }
         changeSink = nil
-        notificationObserver = nil
         onUpdate = nil
     }
 
@@ -127,8 +121,7 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
     /// - Parameter onUpdate: A callback to run whenever `control` should update itself.
     func registerOnUpdate(for control: UIView, onUpdate: @escaping (() -> Void)) {
         guard self.onUpdate == nil,
-              changeSink == nil,
-              notificationObserver == nil else {
+              changeSink == nil else {
             assertionFailure("Attempting to double-register for tokenSet updates!")
             return
         }
@@ -160,9 +153,6 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
 
     /// Holds the sink for any changes to the control token set.
     private var changeSink: AnyCancellable?
-
-    /// Stores the notification handler for .didChangeTheme notifications.
-    private var notificationObserver: NSObjectProtocol?
 
     /// A callback to be invoked after the token set has completed updating.
     private var onUpdate: (() -> Void)?

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -140,24 +140,17 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
                 self?.onUpdate?()
             }
         }
-
-        // Register for notifications in order to call update() when the theme changes.
-        notificationObserver = NotificationCenter.default.addObserver(forName: .didChangeTheme,
-                                                                      object: nil,
-                                                                      queue: nil) { [weak self, weak control] notification in
-            guard let strongSelf = self,
-                  let themeView = notification.object as? UIView,
-                  let control,
-                  control.isDescendant(of: themeView)
-            else {
-                return
-            }
-            strongSelf.update(themeView.fluentTheme)
-        }
     }
 
     /// The current `FluentTheme` associated with this `ControlTokenSet`.
-    var fluentTheme: FluentTheme = FluentTheme.shared
+    var fluentTheme: FluentTheme = FluentTheme.shared {
+        didSet {
+            guard let onUpdate else {
+                return
+            }
+            onUpdate()
+        }
+    }
 
     /// Access to raw overrides for the `ControlTokenSet`.
     @Published private var valueOverrides: [T: ControlTokenValue]?

--- a/ios/FluentUI/Core/Theme/Tokens/TokenizedControl.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenizedControl.swift
@@ -20,3 +20,24 @@ protocol TokenizedControlInternal: TokenizedControl {
     /// The current `FluentTheme` applied to this control. Usually acquired via the environment.
     var fluentTheme: FluentTheme { get }
 }
+
+protocol TokenizedThemeObserver: TokenizedControlInternal, NSObject {
+    func addThemeObserver(for view: UIView) -> NSObjectProtocol
+}
+
+extension TokenizedThemeObserver {
+    @discardableResult func addThemeObserver(for view: UIView) -> NSObjectProtocol {
+        return NotificationCenter.default.addObserver(forName: .didChangeTheme,
+                                                      object: nil,
+                                                      queue: nil) { [weak self, weak view] notification in
+            guard let strongSelf = self,
+                  let themeView = notification.object as? UIView,
+                  let view,
+                  view.isDescendant(of: themeView)
+            else {
+                return
+            }
+            strongSelf.tokenSet.update(themeView.fluentTheme)
+        }
+    }
+}

--- a/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
@@ -38,23 +38,3 @@ extension TokenizedControlView {
     }
 }
 // swiftlint:enable extension_access_modifier
-
-extension View {
-    /// Applies a given `FluentTheme` and `configuration` to  the control's token set.
-    ///
-    /// Use the `configuration` function to set additional properties on the `tokenSet` as needed. For example, some
-    /// controls may need different tokens back for different sized components, so this callback should be used as an
-    /// opportunity to perform that configuration on `tokenSet`.
-    ///
-    /// - Parameter tokenSet: The control's `ControlTokenSet` that should be updated.
-    /// - Parameter fluentTheme: The current `FluentTheme` for the given rendering context.
-    ///
-    /// - Returns: The rendered view after applying updates.
-    func fluentTokens<TokenSetType: Hashable>(_ tokenSet: ControlTokenSet<TokenSetType>,
-                                              _ fluentTheme: FluentTheme) -> some View {
-        return self
-            .onChange(of: fluentTheme) { newTheme in
-                tokenSet.update(newTheme)
-            }
-    }
-}

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: - DateTimePickerViewComponentCell
 
 /// TableViewCell representing the cell of component view (should be used only by DateTimePickerViewComponent and not instantiated on its own)
-class DateTimePickerViewComponentCell: UITableViewCell, TokenizedControlInternal {
+class DateTimePickerViewComponentCell: UITableViewCell, TokenizedThemeObserver {
     private struct Constants {
         static let baseHeight: CGFloat = 45
         static let verticalPadding: CGFloat = 12
@@ -44,6 +44,7 @@ class DateTimePickerViewComponentCell: UITableViewCell, TokenizedControlInternal
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTextLabelColor()
         }
+        addThemeObserver(for: self)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Divider/Divider.swift
+++ b/ios/FluentUI/Divider/Divider.swift
@@ -41,6 +41,7 @@ public struct FluentDivider: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         let isHorizontal = state.orientation == .horizontal
         let color = Color(tokenSet[.color].color)
         let padding = tokenSet[.padding].float
@@ -58,7 +59,6 @@ public struct FluentDivider: View, TokenizedControlView {
                                   leading: padding,
                                   bottom: 0,
                                   trailing: padding))
-            .fluentTokens(tokenSet, fluentTheme)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -97,7 +97,7 @@ public protocol DrawerControllerDelegate: AnyObject {
  */
 
 @objc(MSFDrawerController)
-open class DrawerController: UIViewController, TokenizedControlInternal {
+open class DrawerController: UIViewController, TokenizedThemeObserver {
     /// DrawerController colors with obj-c support
     @objc public static func drawerBackgroundColor(fluentTheme: FluentTheme?) -> UIColor {
         let theme = fluentTheme ?? .shared
@@ -516,6 +516,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: view) { [weak self] in
             self?.updateBackgroundColor()
         }
+        addThemeObserver(for: view)
     }
 
     open override func viewWillAppear(_ animated: Bool) {

--- a/ios/FluentUI/HUD/HeadsUpDisplay.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplay.swift
@@ -44,12 +44,13 @@ public struct HeadsUpDisplay: View, TokenizedControlView {
     @ObservedObject public var tokenSet: HeadsUpDisplayTokenSet
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         let label = state.label ?? ""
         let type = state.type
         let verticalPadding = HeadsUpDisplayTokenSet.verticalPadding
         let horizontalPadding = HeadsUpDisplayTokenSet.horizontalPadding
 
-        HStack(alignment: .center) {
+        return HStack(alignment: .center) {
             VStack {
                 switch type {
                 case .activity:
@@ -92,11 +93,11 @@ public struct HeadsUpDisplay: View, TokenizedControlView {
         .squareShaped(minSize: HeadsUpDisplayTokenSet.minSize,
                       maxSize: HeadsUpDisplayTokenSet.maxSize)
         .background(Rectangle()
-                        .fill(Color(tokenSet[.backgroundColor].uiColor))
-                        .frame(maxWidth: .infinity,
-                               maxHeight: .infinity,
-                               alignment: .center)
-                        .cornerRadius(tokenSet[.cornerRadius].float)
+            .fill(Color(tokenSet[.backgroundColor].uiColor))
+            .frame(maxWidth: .infinity,
+                   maxHeight: .infinity,
+                   alignment: .center)
+                .cornerRadius(tokenSet[.cornerRadius].float)
         )
         .contentShape(Rectangle())
         .onChange(of: isPresented, perform: { present in
@@ -114,7 +115,6 @@ public struct HeadsUpDisplay: View, TokenizedControlView {
         .onTapGesture {
             state.tapAction?()
         }
-        .fluentTokens(tokenSet, fluentTheme)
     }
 
     /// Initializes the SwiftUI View for the Heads-up display.

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -32,6 +32,7 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         let height = IndeterminateProgressBarTokenSet.height
         let gradientColor = Color(tokenSet[.gradientColor].uiColor)
         let backgroundColor = Color(tokenSet[.backgroundColor].uiColor)
@@ -49,7 +50,7 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
         let accessibilityIdentifier: String = "Indeterminate Progress Bar that is \(state.isAnimating ? "in progress" : "progress halted")"
 #endif
 
-        Rectangle()
+        return Rectangle()
             .fill(LinearGradient(gradient: Gradient(colors: [backgroundColor, gradientColor, backgroundColor]),
                                  startPoint: startPoint,
                                  endPoint: endPoint))
@@ -73,13 +74,12 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
             .modifyIf(!state.isAnimating) { view in
                 view
                     .onAppear {
-                       stopAnimation()
+                        stopAnimation()
                     }
             }
             .modifyIf(!state.isAnimating && state.hidesWhenStopped, { view in
                 view.hidden()
             })
-            .fluentTokens(tokenSet, fluentTheme)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -7,7 +7,7 @@ import UIKit
 
 // MARK: BadgeLabel
 
-class BadgeLabel: UILabel, TokenizedControlInternal {
+class BadgeLabel: UILabel, TokenizedThemeObserver {
     var shouldUseWindowColor: Bool = false {
         didSet {
             updateColors()
@@ -37,6 +37,7 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColors()
         }
+        addThemeObserver(for: self)
     }
 
     override func willMove(toWindow newWindow: UIWindow?) {

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// By default, `adjustsFontForContentSizeCategory` is set to true to automatically update its font when device's content size category changes
 @objc(MSFLabel)
-open class Label: UILabel, TokenizedControlInternal {
+open class Label: UILabel, TokenizedThemeObserver {
     @objc open var colorStyle: TextColorStyle = .regular {
         didSet {
             updateTextColor()
@@ -125,6 +125,7 @@ open class Label: UILabel, TokenizedControlInternal {
             self?.updateTextColor()
             self?.updateFont()
         }
+        addThemeObserver(for: self)
     }
 
     private func updateFont() {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -53,7 +53,7 @@ open class NavigationBarTopSearchBarAttributes: NavigationBarTopAccessoryViewAtt
 /// Contains the MSNavigationTitleView class and handles passing animatable progress through
 /// Custom UI can be hidden if desired
 @objc(MSFNavigationBar)
-open class NavigationBar: UINavigationBar, TokenizedControlInternal {
+open class NavigationBar: UINavigationBar, TokenizedThemeObserver {
     /// If the style is `.custom`, UINavigationItem's `navigationBarColor` is used for all the subviews' backgroundColor
     @objc(MSFNavigationBarStyle)
     public enum Style: Int {
@@ -361,6 +361,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColors(for: self?.topItem)
         }
+        addThemeObserver(for: self)
     }
 
     private func updateTopAccessoryView(for navigationItem: UINavigationItem?) {

--- a/ios/FluentUI/Navigation/SearchBar/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar/SearchBar.swift
@@ -22,7 +22,7 @@ public protocol SearchBarDelegate: AnyObject {
 
 /// Drop-in replacement for UISearchBar that allows for more customization
 @objc(MSFSearchBar)
-open class SearchBar: UIView, TokenizedControlInternal {
+open class SearchBar: UIView, TokenizedThemeObserver {
     @objc open var hidesNavigationBarDuringSearch: Bool = true {
         didSet {
             if oldValue != hidesNavigationBarDuringSearch && isActive {
@@ -180,6 +180,7 @@ open class SearchBar: UIView, TokenizedControlInternal {
             self?.updateColorsForStyle()
             self?.updateFonts()
         }
+        addThemeObserver(for: self)
     }
 
     open override func willMove(toWindow newWindow: UIWindow?) {

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -11,7 +11,7 @@ import UIKit
 /// Used to contain an accessory provided by the VC contained by the NavigatableShyContainerVC
 /// This class in itself is fairly straightforward, defining a height and a containment layout
 /// The animation around showing/hiding this view progressively is handled by its superview/superVC, an instance of ShyHeaderController
-class ShyHeaderView: UIView, TokenizedControlInternal {
+class ShyHeaderView: UIView, TokenizedThemeObserver {
     typealias TokenSetKeyType = EmptyTokenSet.Tokens
     public var tokenSet: EmptyTokenSet = .init()
 
@@ -72,6 +72,7 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColors()
         }
+        addThemeObserver(for: self)
     }
 
     override func willMove(toWindow newWindow: UIWindow?) {

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -336,7 +336,6 @@ public struct FluentNotification: View, TokenizedControlView {
         }
 
         return presentableNotification
-            .fluentTokens(tokenSet, fluentTheme)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -127,6 +127,7 @@ public struct FluentNotification: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         @ViewBuilder
         var image: some View {
             if state.style.isToast {

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -15,7 +15,7 @@ import UIKit
  `topSeparatorType` and `bottomSeparatorType` can be used to show custom horizontal separators. Make sure to remove the `UITableViewCell` built-in separator by setting `separatorStyle = .none` on your table view.
  */
 @objc(MSFActionsCell)
-open class ActionsCell: UITableViewCell, TokenizedControlInternal {
+open class ActionsCell: UITableViewCell, TokenizedThemeObserver {
     @objc(MSFActionsCellActionType)
     public enum ActionType: Int {
         case regular
@@ -138,6 +138,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     public required init(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: ActivityIndicatorCell
 
 @objc(MSFActivityIndicatorCell)
-open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
+open class ActivityIndicatorCell: UITableViewCell, TokenizedThemeObserver {
     public static let identifier: String = "ActivityIndicatorCell"
 
     @objc public var backgroundStyleType: TableViewCellBackgroundStyleType = .plain {
@@ -43,6 +43,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     @objc public required init(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: CenteredLabelCell
 
 @objc(MSFCenteredLabelCell)
-open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
+open class CenteredLabelCell: UITableViewCell, TokenizedThemeObserver {
     public static let identifier: String = "CenteredLabelCell"
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
@@ -47,6 +47,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     @objc public required init(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButton.swift
@@ -68,8 +68,9 @@ public struct PersonaButton: View, TokenizedControlView {
     }
 
     public var body: some View {
+        tokenSet.update(fluentTheme)
         let action = state.onTapAction ?? {}
-        SwiftUI.Button(action: action) {
+        return SwiftUI.Button(action: action) {
             VStack(spacing: 0) {
                 avatarView
                 personaText
@@ -78,7 +79,6 @@ public struct PersonaButton: View, TokenizedControlView {
         }
         .frame(minWidth: adjustedWidth, maxWidth: adjustedWidth, minHeight: 0, maxHeight: .infinity)
         .background(Color(tokenSet[.backgroundColor].uiColor))
-        .fluentTokens(tokenSet, fluentTheme)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -95,7 +95,8 @@ public struct PersonaButtonCarousel: View, TokenizedControlView {
     }
 
     public var body: some View {
-        SwiftUI.ScrollView(.horizontal, showsIndicators: false) {
+        tokenSet.update(fluentTheme)
+        return SwiftUI.ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 0) {
                 ForEach(state.buttons, id: \.self) { buttonState in
                     PersonaButton(state: buttonState) { [weak state] in
@@ -109,7 +110,6 @@ public struct PersonaButtonCarousel: View, TokenizedControlView {
             }
         }
         .background(Color(tokenSet[.backgroundColor].uiColor))
-        .fluentTokens(tokenSet, fluentTheme)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// A `PillButton` is a button in the shape of a pill that can have two states: on (Selected) and off (not selected)
 @objc(MSFPillButton)
-open class PillButton: UIButton, TokenizedControlInternal {
+open class PillButton: UIButton, TokenizedThemeObserver {
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         guard self == context.nextFocusedView || self == context.previouslyFocusedView else {
@@ -49,6 +49,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: - ResizingHandleView
 
 @objc(MSFResizingHandleView)
-open class ResizingHandleView: UIView, TokenizedControlInternal {
+open class ResizingHandleView: UIView, TokenizedThemeObserver {
     @objc public static let height: CGFloat = 20
 
     private lazy var markLayer: CALayer = {
@@ -32,6 +32,7 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColors()
         }
+        addThemeObserver(for: self)
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -7,7 +7,7 @@ import UIKit
 // MARK: SegmentedControl
 /// A styled segmented control that should be used instead of UISegmentedControl. It is designed to flex the button width proportionally to the control's width.
 @objc(MSFSegmentedControl)
-open class SegmentedControl: UIView, TokenizedControlInternal {
+open class SegmentedControl: UIView, TokenizedThemeObserver {
     private struct Constants {
         static let selectionBarHeight: CGFloat = 1.5
         static let pillContainerHorizontalInset: CGFloat = 16
@@ -214,6 +214,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTokenizedValues()
         }
+        addThemeObserver(for: self)
         updateTokenizedValues()
     }
 

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 /// View that converts the subviews of a container view into a loading state with the "shimmering" effect.
 @objc(MSFShimmerView)
-open class ShimmerView: UIView, TokenizedControlInternal {
+open class ShimmerView: UIView, TokenizedThemeObserver {
 
     /// Optional synchronizer to sync multiple shimmer views.
     @objc open weak var animationSynchronizer: AnimationSynchronizerProtocol?
@@ -61,6 +61,7 @@ open class ShimmerView: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateShimmeringAnimation()
         }
+        addThemeObserver(for: self)
     }
 
     required public init?(coder: NSCoder) {

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -23,7 +23,7 @@ public protocol SideTabBarDelegate {
 /// View for a vertical side tab bar that can be used for app navigation.
 /// Optimized for horizontal regular + vertical regular size class configuration. Prefer using TabBarView for other size class configurations.
 @objc(MSFSideTabBar)
-open class SideTabBar: UIView, TokenizedControlInternal {
+open class SideTabBar: UIView, TokenizedThemeObserver {
     /// Delegate to handle user interactions in the side tab bar.
     @objc public weak var delegate: SideTabBarDelegate? {
         didSet {
@@ -135,6 +135,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     @available(*, unavailable)

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-class TabBarItemView: UIControl, TokenizedControlInternal {
+class TabBarItemView: UIControl, TokenizedThemeObserver {
     let item: TabBarItem
 
     typealias TokenSetKeyType = TabBarItemTokenSet.Tokens
@@ -135,6 +135,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -20,7 +20,7 @@ public protocol TabBarViewDelegate {
 /// Set up `items` array to determine the order of `TabBarItems` to show.
 /// Use `selectedItem` property to change the selected tab bar item.
 @objc(MSFTabBarView)
-open class TabBarView: UIView, TokenizedControlInternal {
+open class TabBarView: UIView, TokenizedThemeObserver {
     /// List of TabBarItems in the TabBarView. Order of the array is the order of the subviews.
     @objc open var items: [TabBarItem] = [] {
         willSet {
@@ -109,6 +109,7 @@ open class TabBarView: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     required public init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -104,7 +104,7 @@ Specify `accessoryType` on setup to show either a disclosure indicator or a `det
 NOTE: This cell implements its own custom separator. Make sure to remove the UITableViewCell built-in separator by setting `separatorStyle = .none` on your table view. To remove the cell's custom separator set `bottomSeparatorType` to `.none`.
 */
 @objc(MSFTableViewCell)
-open class TableViewCell: UITableViewCell, TokenizedControlInternal {
+open class TableViewCell: UITableViewCell, TokenizedThemeObserver {
     @objc(MSFTableViewCellSeparatorType)
     public enum SeparatorType: Int {
         case none
@@ -1303,6 +1303,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
+        addThemeObserver(for: self)
     }
 
     /// Sets up the cell with text, a custom view, a custom accessory view, and an accessory type

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -21,7 +21,7 @@ public protocol TableViewHeaderFooterViewDelegate: AnyObject {
 /// The optional accessory button should only be used with `default` style headers with the `title` as a single line of text.
 /// Use `titleNumberOfLines` to configure the number of lines for the `title`. Headers generally use the default number of lines of 1 while footers may use a multiple number of lines.
 @objc(MSFTableViewHeaderFooterView)
-open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedControlInternal {
+open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedThemeObserver {
     @objc public static var identifier: String { return String(describing: self) }
 
     /// The height of the view based on the height of its content.
@@ -234,6 +234,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             self?.updateTitleAndBackgroundColors()
             self?.updateAccessoryButtonTitleColor()
         }
+        addThemeObserver(for: self)
     }
 
     // MARK: Setup

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 @objc(MSFTextField)
-public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedControlInternal {
+public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedThemeObserver {
     public override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         guard let newWindow else {
@@ -151,6 +151,7 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTokenizedValues()
         }
+        addThemeObserver(for: self)
     }
 
     required init?(coder: NSCoder) {

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -17,7 +17,7 @@ import UIKit
 // |--|--layer (ambient and key shadows added as sublayers)
 /// A styled tooltip that is presented anchored to a view.
 @objc(MSFTooltip)
-open class Tooltip: NSObject, TokenizedControlInternal {
+open class Tooltip: NSObject, TokenizedThemeObserver {
 
     /// Displays a tooltip based on the current settings, pointing to the supplied anchorView.
     /// If another tooltip view is already showing, it will be dismissed and the new tooltip will be shown.
@@ -66,6 +66,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: tooltipView) { [weak self] in
             self?.tooltipViewController?.updateAppearance()
         }
+        themeObserver = addThemeObserver(for: tooltipView)
 
         hostVC.addChild(tooltipViewController)
         self.onTap = onTap
@@ -218,6 +219,12 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         tooltipViewController = nil
 
         tokenSet.deregisterOnUpdate()
+        if let themeObserver {
+            NotificationCenter.default.removeObserver(themeObserver,
+                                                      name: .didChangeTheme,
+                                                      object: nil)
+        }
+        themeObserver = nil
 
         onTap = nil
 
@@ -282,6 +289,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         }
         return anchorView.fluentTheme
     }
+    var themeObserver: NSObjectProtocol?
 
     private override init() {
         super.init()


### PR DESCRIPTION
Draft POC to see if these changes are worth doing everywhere

The main issue with themes in SwiftUI (after making sure we passed on in from UIKit) was that the control had the right theme, but wasn't able to update its token set until after it had already been drawn. And even then, setting a new theme on the token set wasn't triggering a redraw. To fix that, we can just set the theme at the top of `body`. That ran into issues with `[SwiftUI] Publishing changes from within view updates is not allowed, this will cause undefined behavior.`, so I tried making the `tokenSet` not an `@ObservedObject`. That ran into issues trying to apply token overrides to a UIKit hosted SwiftUI control that was actively being displayed. So I changed it so that the `fluentTheme` in the `tokenSet` wasn't `@Published`. But then that had issues with not responding to theme updates in just UIKit controls (not UIKit hosts of SwiftUI controls), so I moved the observer for `themeDidChange` back to the UIKit control.

Demo:
![Notification_Toggles](https://user-images.githubusercontent.com/67026548/236934313-1cc9e9fe-d001-429f-addb-be1e7d77e1da.gif)
